### PR TITLE
Use Pango for font handling

### DIFF
--- a/Common.py
+++ b/Common.py
@@ -15,6 +15,7 @@
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>
 
 import cairo
+import pango
 import Enum
 
 keytypes = Enum.Enum("SIMPLE SPECIAL").vals(illegal=255)
@@ -27,10 +28,7 @@ keysegmentslist = [keysegments.ONE, keysegments.TWO,
 keysegmentslistreverse = list(keysegmentslist)
 keysegmentslistreverse.reverse()
 
-fontname = "Sans"
-fontstyle = cairo.FONT_SLANT_NORMAL
-fontweight = cairo.FONT_WEIGHT_NORMAL
-fontsize = 12
+font_desc = pango.FontDescription("Sans Bold 12")
 
 # You need to have gucharmap installed.
 # It might be possible to perform drag n drop from the KDE equivalent,

--- a/KeyboardLayoutEditor
+++ b/KeyboardLayoutEditor
@@ -100,7 +100,7 @@ class Controller_KeyboardLayoutEditor:
 
         # Set initial size
         (width, height) = self.window.get_size()
-        self.window.resize(800, 550)
+        self.window.resize(1350, 700)
         
         self.window.connect("check_resize", self.check_resize)
         

--- a/KeyboardLayoutEditor
+++ b/KeyboardLayoutEditor
@@ -277,7 +277,7 @@ Please do not put punctuation marks."
         fontbutton_vbox = gtk.VBox()
         fontbutton_label = gtk.Label("Select a font")
         fontbutton_vbox.pack_start(fontbutton_label, expand=False, fill=False)
-        fontbutton = gtk.FontButton(fontname=Common.fontname + " " + str(Common.fontsize))
+        fontbutton = gtk.FontButton(fontname=Common.font_desc.to_string())
         fontbutton.set_title('Select a font')
         fontbutton.connect('font-set', self.font_set_callback)
         fontbutton_vbox.pack_start(fontbutton, expand=False, fill=False)
@@ -900,23 +900,9 @@ Please do not put punctuation marks."
 
     def font_set_callback(self, fontbutton):
         newfont = fontbutton.get_font_name()
+        font_desc = pango.FontDescription(newfont)
+        Common.font_desc= font_desc
         context = self.window.create_pango_context()
-        for family in context.list_families():
-            if newfont.find(family.get_name()) == 0:
-                face = family.list_faces()[0]
-                Common.fontname = family.get_name()
-                Common.fontsize = string.atoi(newfont.rpartition(' ')[-1], 10)
-                Common.fontstyle = cairo.FONT_SLANT_NORMAL
-                Common.fontweight = cairo.FONT_WEIGHT_NORMAL
-                if face.get_face_name() == "Regular":
-                    Common.fontstyle = cairo.FONT_SLANT_NORMAL
-                if face.get_face_name() == "Bold":
-                    Common.fontweight = cairo.FONT_SLANT_BOLD
-                if face.get_face_name() == "Italic":
-                    Common.fontstyle = cairo.FONT_SLANT_ITALIC
-                if face.get_face_name() == "Oblique":
-                    Common.fontstyle = cairo.FONT_SLANT_OBLIQUE
-                break
         for keycode in KeyDict.Keys.keys():
             KeyDict.Keys[keycode].key.redraw()
         Common.addtostatusbar('Font set to ' + newfont + '.')

--- a/XKBGrammar.g
+++ b/XKBGrammar.g
@@ -38,6 +38,7 @@ tokens
   ELEM_VIRTUALMODS;
   KEYELEMENTS;
   OVERRIDE;
+  REPLACE;
   OVERLAY;
 }
 
@@ -97,7 +98,7 @@ line_keytype
   ;
 
 line_key
-  : OVERRIDE? 'key' '<' NAME '>' '{' keyelements (',' keyelements)* '}'
+  : (OVERRIDE|REPLACE)? 'key' '<' NAME '>' '{' keyelements (',' keyelements)* '}'
   -> ^(TOKEN_KEY OVERRIDE? ^(KEYCODEX NAME) keyelements+)
   ;
 
@@ -118,6 +119,10 @@ keycode
 
 override
   : 'override'
+  ;
+
+replace
+  : 'replace'
   ;
 
 keyelements
@@ -172,6 +177,10 @@ STATE
 
 OVERRIDE
   : 'override'
+  ;
+
+REPLACE
+  : 'replace'
   ;
 
 NAME


### PR DESCRIPTION
Using Pango instead of the Cairo "toy" text API.

- Respect font style (see #25)
- Better text positioning
- Enlarge default window size to have all texts fit by default